### PR TITLE
How is this used with an existing repo?

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,16 +19,26 @@ The usage is basically `Git.COMMAND REPO, ARGS`, where `REPO` is a
 So for example, `git pull --rebase origin master` would translate to
 `Git.pull repo, ~w(--rebase origin master)`.
 
-The only exceptions are `Git.clone` and `Git.init`, which do not take a repository as first argument.
+The only exceptions are `Git.clone`, `Git.init`, and `Git.new`, which do not take a repository as first argument.
 
 Here are a few examples.
 
+### Git.clone Example
 ```elixir
 {:ok, repo} = Git.clone "https://github.com/tuvistavie/elixir-git-cli"
 Git.remote repo, ~w(add upstream https://git.example.com)
 Git.pull repo, ~w(--rebase upstream master)
 Git.diff repo, "HEAD~1"
 Git.add repo, "."
+Git.commit repo, ["-m" "my message"]
+Git.push repo
+IO.puts Git.log!(repo)
+```
+
+### Git.new Example
+```elixir
+repo = Git.new "/path/to/existing/repo"
+IO.puts Git.status! repo
 Git.commit repo, ["-m" "my message"]
 Git.push repo
 IO.puts Git.log!(repo)
@@ -44,7 +54,7 @@ simply raises the exception.
 As this is a wrapper for `git`, you need to have the `git` command available on your path.
 
 The commands are generated from [git-commands.txt](./git-commands.txt),
-except for `init` and `clone` which return a `Git.Repository` struct and not
+except for `init`, `clone`, and `new` which return a `Git.Repository` struct and not
 the git process `stdout`.
 The `apply` command is not generated as it conflicts with elixir Kernel function.
 The commands with dashes have their function equivalent with dashes replaced by underscores, so for example, `git ls-files` become `Git.ls_files`.

--- a/lib/git.ex
+++ b/lib/git.ex
@@ -67,6 +67,17 @@ defmodule Git do
   end
 
   @doc """
+  Return a Git.Repository struct with the specified or defaulted path.
+  For use with an existing repo (when Git.init and Git.clone would not be appropriate).
+  """
+  @spec new(cli_arg) :: Git.Repository.t
+  def new(args \\ []) do
+    args = if is_list(args), do: args, else: [args]
+    path = (Enum.at(args, 0) || ".") |> Path.expand
+    %Git.Repository{path: path}
+  end
+
+  @doc """
   Execute the git command in the given repository.
   """
   @spec execute_command(Repository.t | nil, bitstring, list, (bitstring -> any | error)) :: {:ok, any} | {:error, any}

--- a/lib/git.ex
+++ b/lib/git.ex
@@ -1,6 +1,7 @@
 defmodule Git do
   @type error :: {:error, Git.Error}
   @type cli_arg :: bitstring | list
+  @type path :: bitstring
 
   @doc """
   Clones the repository. The first argument can be `url` or `[url, path]`.
@@ -70,12 +71,8 @@ defmodule Git do
   Return a Git.Repository struct with the specified or defaulted path.
   For use with an existing repo (when Git.init and Git.clone would not be appropriate).
   """
-  @spec new(cli_arg) :: Git.Repository.t
-  def new(args \\ []) do
-    args = if is_list(args), do: args, else: [args]
-    path = (Enum.at(args, 0) || ".") |> Path.expand
-    %Git.Repository{path: path}
-  end
+  @spec new(path) :: Git.Repository.t
+  def new(path \\ "."), do: %Git.Repository{path: path}
 
   @doc """
   Execute the git command in the given repository.

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Git.Mixfile do
 
   def project do
     [app: :git_cli,
-     version: "0.2.1",
+     version: "0.2.2",
      elixir: "~> 1.0",
      name: "git_cli",
      source_url: "https://github.com/tuvistavie/elixir-git-cli",

--- a/test/git_test.exs
+++ b/test/git_test.exs
@@ -22,6 +22,15 @@ defmodule GitTest do
     Temp.cleanup
   end
 
+  # Verify :new allows use of a pre-existing repo
+  test :new, %{dir: dir} do
+    Git.init! dir
+
+    repo = Git.new dir
+    assert File.exists?(repo.path)
+    assert File.exists?(Path.join(repo.path, ".git"))
+  end
+
   test :add, %{dir: dir} do
     repo = Git.init! dir
     assert String.length(Git.status! repo, ~w(-s)) == 0

--- a/test/git_test.exs
+++ b/test/git_test.exs
@@ -29,6 +29,7 @@ defmodule GitTest do
     repo = Git.new dir
     assert File.exists?(repo.path)
     assert File.exists?(Path.join(repo.path, ".git"))
+    Temp.cleanup
   end
 
   test :add, %{dir: dir} do


### PR DESCRIPTION
Say I have an existing repo on disk and want a small elixir CLI using elixir-git-cli to manipulate what is already there.

Neither Git.init, nor Git.clone seems right - is there a way to set up the Git.Repository for an existing repo (or not implemented yet)? If there is, I'll issue a PR to add that info to your README.md