### PR TITLE
Elinate errors due to Elixir 1.4 changes

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -8,11 +8,11 @@ defmodule Git.Mixfile do
      name: "git_cli",
      source_url: "https://github.com/tuvistavie/elixir-git-cli",
      homepage_url: "https://github.com/tuvistavie/elixir-git-cli",
-     package: package,
-     description: description,
+     package: package(),
+     description: description(),
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     deps: deps]
+     deps: deps()]
   end
 
   def application do


### PR DESCRIPTION
This pull request adds parens to function calls that need them.  Elixir 1.4 throws a warning when a function is called without using parens.

Before change:

    $ mix compile
    warning: variable "package" does not exist and is being expanded to "package()", please use parentheses to remove the ambiguity or change the variable name
      mix.exs:11

    warning: variable "description" does not exist and is being expanded to "description()", please use parentheses to remove the ambiguity or change the variable name
      mix.exs:12

    warning: variable "deps" does not exist and is being expanded to "deps()", please use parentheses to remove the ambiguity or change the variable name
      mix.exs:15

    Compiling 3 files (.ex)
    Generated git_cli app

After change:

    $ mix compile
    Compiling 3 files (.ex)
    Generated git_cli app